### PR TITLE
Apply open-languages setting to disclosures

### DIFF
--- a/exports/components/light-pen/light-pen.js
+++ b/exports/components/light-pen/light-pen.js
@@ -536,10 +536,11 @@ export default class LightPen extends BaseElement {
   renderDetails(language) {
     let fullLanguage = language.toUpperCase();
 
-    // const open = this.openLanguages.split(",").includes(language)
+    const open = this.openLanguages.split(",").includes(language)
 
     return html`
-      <light-disclosure part="disclosure disclosure-${language}">
+      <light-disclosure part="disclosure disclosure-${language}"
+        ${open ? 'open' : ''}>
         <span part="summary" slot="summary"
           ><slot name=${`summary-${language}`}>${fullLanguage}</slot></span
         >


### PR DESCRIPTION
Even uncommenting that line, it seems like the result wasn't applied anywhere. I think this should apply it as well.

I wasn't able to `npm install` or run tests, because my system doesn't recognize the `link:.` syntax for an npm package. Not sure if there's something I need to set up for that.

Hope this helps!

Fixes #35 